### PR TITLE
Add neon git cockpit terminal UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,85 @@
 
 An interactive script for managing Git operations, GitHub Pages deployment, and SSH key management. This script helps automate common Git tasks and integrates with GitHub Pages and GitHub Codespaces. It also provides utilities for generating and managing SSH keys.
 
+## Neon Git Cockpit (Terminal UI)
+
+Prefer a neon-lit command center instead of memorising dozens of git commands? Launch the curses-powered **neon git cockpit** and cruise through commits, branches, GitHub issues, and dangerous operations without leaving the terminal.
+
+```text
+┌─────────────────────────────── NEON GIT COCKPIT ───────────────────────────────┐
+│ HEAD: main | Theme: github_dark | View: diff                                   │
+├─────────────────────────┬──────────────────────────────────────────────────────┤
+│ Timeline                │ Diff / GitHub / Danger Zone Panel                   │
+│ ➤ 9f31b1 2025-08-20 ch  │ commit 9f31b1 (Chris)                               │
+│   41a62a 2025-08-19 fea │ + Add neon cockpit + GitHub sync panel              │
+│   3d9c72 2025-08-18 fix │ - Remove brittle shell prompts                      │
+├─────────────────────────┴──────────────────────────────────────────────────────┤
+│ Status: press ? for hotkeys           Undo:1  Redo:0  GitHub: issues ▷ pulls   │
+└────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Cockpit superpowers
+
+* **Repo browser** – scroll commits with ↑/↓, press `Enter` for rich diffs, `Space` to pop into a temporary branch.
+* **Branch playground** – jump to the branch graph, fast-forward with `F`, or merge after previewing diff stats.
+* **GitHub sync** – hit `G` for live lists of issues, pull requests, and Actions runs (powered by the `gh` CLI). Type `#42` in search to grab a specific PR instantly.
+* **Danger zone** – slam `D` to reveal rollback, skull-certified force push, and stashing prompts (with built-in safety nets).
+* **Interactive rebase** – `R` launches a GUI-like checklist. Use `p/s/f/e/r/x` to mark actions before executing.
+* **Plug-ins** – press `P` for extensibility. A sample “ML-ish commit oracle” plugin analyses your diff and proposes cheeky messages.
+* **Themes & vibes** – configuration lives at `~/.config/neon_git/config.json` with presets for GitHub Dark, Matrix Green, and Neon Cyberpunk.
+
+### Quickstart
+
+```bash
+python3 neogit.py
+```
+
+Key hotkeys are always a `?` away:
+
+| Key | Action |
+| --- | --- |
+| `↑/↓` | Navigate commits |
+| `Space` | Checkout selected commit in a temporary branch |
+| `Tab` | Create a new branch from the highlighted commit |
+| `F` | Fast-forward to the tracked main branch |
+| `G` | Open GitHub panel (requires [`gh`](https://cli.github.com/)) |
+| `R` | Launch interactive rebase planner |
+| `P` | Browse and run plug-ins |
+| `D` | Toggle the danger zone overlay |
+| `/` | Search commits or jump to `#<issue>`/`#<PR>` |
+| `U` / `Shift+U` | Undo / redo git state snapshots |
+| `Q` | Quit the cockpit |
+
+> **GitHub integration:** the cockpit auto-detects your `origin` remote. Make sure `gh auth login` has been run and the CLI is in PATH.
+
+### Plug-in architecture
+
+Drop Python modules inside `neogit_tui/plugins/` that expose a `register()` function returning a `Plugin`. Each plug-in receives the active `GitInterface` instance, so you can build bots for semantic PR labels, AI commit messages, or workflow dashboards.
+
+```python
+from neogit_tui.git import GitInterface
+from neogit_tui.plugins import Plugin
+
+
+def register() -> Plugin:
+    def run(git: GitInterface, app) -> str:
+        summary = git.diff_stat()
+        return f"Diff summary\n{summary}"
+
+    return Plugin(
+        name="Diff Summariser",
+        description="Show a quick diffstat report",
+        run=run,
+    )
+```
+
+Restart the cockpit and your plug-in appears instantly in the `P` menu.
+
 ## Features
+
+### Classic Bash Helper
+
+If you prefer the original guided prompts, the `ghHelper.sh` script is still included.
 
 ### General Git Operations:
 

--- a/neogit.py
+++ b/neogit.py
@@ -1,0 +1,7 @@
+"""Entry point for the neon git cockpit."""
+
+from neogit_tui import run
+
+
+if __name__ == "__main__":
+    run()

--- a/neogit_tui/__init__.py
+++ b/neogit_tui/__init__.py
@@ -1,0 +1,5 @@
+"""Neon-powered Git + GitHub terminal cockpit."""
+
+from .app import run
+
+__all__ = ["run"]

--- a/neogit_tui/app.py
+++ b/neogit_tui/app.py
@@ -1,0 +1,709 @@
+"""Curses powered neon Git cockpit."""
+
+from __future__ import annotations
+
+import curses
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from .config import apply_theme, resolve_theme
+from .git import Commit, GitCommandError, GitInterface, HeadSnapshot
+from .github import GitHubClient, GitHubItem, GitHubUnavailable, WorkflowRun, try_create_client
+from .plugins import Plugin, load_plugins
+
+
+@dataclass
+class RebaseEntry:
+    commit: Commit
+    action: str = "pick"
+
+
+@dataclass
+class AppState:
+    commits: List[Commit]
+    selected: int = 0
+    view: str = "diff"  # diff, branches, github, danger, rebase, plugins
+    status: str = "Welcome to the neon cockpit."
+    help_visible: bool = False
+    undo_stack: List[HeadSnapshot] = field(default_factory=list)
+    redo_stack: List[HeadSnapshot] = field(default_factory=list)
+    github_tab: str = "issues"
+    github_error: Optional[str] = None
+    plugin_output: Optional[str] = None
+    rebase_entries: List[RebaseEntry] = field(default_factory=list)
+    rebase_cursor: int = 0
+    plugin_index: int = 0
+    danger_mode: bool = False
+
+
+HELP_TEXT = [
+    "Arrows: navigate commits",
+    "Enter: focus diff",
+    "Space: checkout commit in temp branch",
+    "Tab: create branch from commit",
+    "F: fast-forward to main",
+    "M: merge preview",
+    "B: branch playground",
+    "G: GitHub sync center",
+    "R: interactive rebase planner",
+    "P: run plug-ins",
+    "D: danger zone",
+    "U: undo | Shift+U: redo",
+    "/: search (#42 hits GitHub)",
+    "?: toggle this help",
+    "Q: exit",
+]
+
+GITHUB_TABS = ["issues", "pulls", "actions"]
+
+
+class NeonGitApp:
+    def __init__(self, stdscr: curses.window):
+        self.stdscr = stdscr
+        self.git = GitInterface()
+        self.theme = resolve_theme()
+        self.colors = apply_theme(self.theme)
+        curses.curs_set(0)
+        self.stdscr.timeout(200)
+        commits = self.git.list_commits()
+        self.state = AppState(commits=commits)
+        self.diff_cache: Dict[str, str] = {}
+        self.github: Optional[GitHubClient] = try_create_client(self.git)
+        if not self.github:
+            self.state.github_error = "GitHub CLI unavailable or remote not set."
+        self.github_cache: Dict[str, List[GitHubItem] | List[WorkflowRun]] = {}
+        self.plugins: List[Plugin] = load_plugins()
+        self.state.status = f"Loaded {len(commits)} commits. Press ? for help."
+
+    # ------------------------------------------------------------------ rendering
+    def render(self) -> None:
+        self.stdscr.erase()
+        max_y, max_x = self.stdscr.getmaxyx()
+        header_height = 3
+        status_height = 2
+        body_height = max_y - header_height - status_height
+        body_height = max(body_height, 10)
+        timeline_width = max(int(max_x * 0.45), 40)
+        detail_width = max_x - timeline_width
+
+        header_win = curses.newwin(header_height, max_x, 0, 0)
+        timeline_win = curses.newwin(body_height, timeline_width, header_height, 0)
+        detail_win = curses.newwin(body_height, detail_width, header_height, timeline_width)
+        status_win = curses.newwin(status_height, max_x, header_height + body_height, 0)
+
+        self._render_header(header_win)
+        self._render_timeline(timeline_win)
+        self._render_detail(detail_win)
+        self._render_status(status_win)
+
+        if self.state.help_visible:
+            self._render_help_overlay()
+        if self.state.danger_mode:
+            self._render_danger_overlay()
+
+        self.stdscr.refresh()
+
+    def _render_header(self, win: curses.window) -> None:
+        win.bkgd(" ", curses.color_pair(self.colors["panel"]))
+        win.erase()
+        title = " NEON GIT COCKPIT "
+        win.addstr(1, 2, title, curses.color_pair(self.colors["accent"]) | curses.A_BOLD)
+        branch = self.git.current_branch() or "detached"
+        win.addstr(1, len(title) + 3, f"| HEAD: {branch}")
+        win.addstr(1, len(title) + 22, f"| Theme: {self.theme.name}")
+        win.addstr(1, len(title) + 45, f"| View: {self.state.view}")
+        win.noutrefresh()
+
+    def _render_timeline(self, win: curses.window) -> None:
+        win.box()
+        height, width = win.getmaxyx()
+        available = height - 2
+        start = max(0, self.state.selected - available + 1)
+        end = min(len(self.state.commits), start + available)
+        for idx, commit in enumerate(self.state.commits[start:end], start=start):
+            marker = "➤" if idx == self.state.selected else " "
+            subject = commit.subject[: width - 20]
+            line = f"{marker} {commit.short_hash} {commit.date} {commit.author[:8]:<8} {subject}"
+            attr = curses.color_pair(self.colors["default"])
+            if idx == self.state.selected:
+                attr |= curses.A_REVERSE
+            win.addstr(idx - start + 1, 1, line.ljust(width - 2), attr)
+        win.noutrefresh()
+
+    def _render_detail(self, win: curses.window) -> None:
+        win.box()
+        height, width = win.getmaxyx()
+        content_width = width - 4
+        if not self.state.commits:
+            win.addstr(1, 2, "No commits found")
+            win.noutrefresh()
+            return
+
+        if self.state.view == "diff":
+            commit = self.state.commits[self.state.selected]
+            text = self._get_diff(commit)
+            self._draw_text_block(win, text, content_width)
+        elif self.state.view == "branches":
+            graph = self.git.branch_graph()
+            self._draw_text_block(win, graph, content_width)
+        elif self.state.view == "github":
+            self._render_github_panel(win, content_width)
+        elif self.state.view == "rebase":
+            self._render_rebase_panel(win, content_width)
+        elif self.state.view == "plugins":
+            self._render_plugin_panel(win, content_width)
+        elif self.state.view == "danger":
+            self._render_danger_panel(win, content_width)
+        else:
+            win.addstr(1, 2, f"Unknown view: {self.state.view}")
+        win.noutrefresh()
+
+    def _render_status(self, win: curses.window) -> None:
+        win.bkgd(" ", curses.color_pair(self.colors["panel"]))
+        win.erase()
+        status = self.state.status[: win.getmaxyx()[1] - 2]
+        win.addstr(0, 1, status)
+        undo_redo = f"Undo:{len(self.state.undo_stack)} | Redo:{len(self.state.redo_stack)}"
+        win.addstr(1, 1, undo_redo, curses.color_pair(self.colors["muted"]))
+        win.noutrefresh()
+
+    def _draw_text_block(self, win: curses.window, text: str, width: int) -> None:
+        lines = text.splitlines()
+        height, _ = win.getmaxyx()
+        max_lines = height - 2
+        for idx, line in enumerate(lines[:max_lines]):
+            attr = curses.color_pair(self.colors["default"])
+            if line.startswith("+"):
+                attr = curses.color_pair(self.colors["success"])
+            elif line.startswith("-"):
+                attr = curses.color_pair(self.colors["danger"])
+            elif line.startswith("commit"):
+                attr = curses.color_pair(self.colors["accent"]) | curses.A_BOLD
+            win.addstr(idx + 1, 2, line[:width], attr)
+
+    # ------------------------------------------------------------- detail panels
+    def _render_github_panel(self, win: curses.window, width: int) -> None:
+        if self.state.github_error:
+            win.addstr(1, 2, self.state.github_error)
+            return
+        if not self.github:
+            win.addstr(1, 2, "GitHub features unavailable.")
+            return
+        win.addstr(1, 2, f"GitHub {self.state.github_tab.title()} (←/→ to switch)", curses.A_BOLD)
+        items = self._ensure_github_data(self.state.github_tab)
+        lines = []
+        if self.state.github_tab == "actions":
+            for run in items:  # type: ignore[assignment]
+                assert isinstance(run, WorkflowRun)
+                lines.append(f"▶ {run.name} | {run.status} | {run.conclusion or '—'}")
+                lines.append(f"   {run.created_at} -> {run.url}")
+        else:
+            for item in items:  # type: ignore[assignment]
+                assert isinstance(item, GitHubItem)
+                lines.append(f"#{item.number} [{item.state}] {item.title}")
+                lines.append(f"   by {item.author} @ {item.updated_at}")
+                lines.append(f"   {item.url}")
+        if not lines:
+            lines.append("No data retrieved yet.")
+        self._draw_text_block(win, "\n".join(lines), width)
+
+    def _render_rebase_panel(self, win: curses.window, width: int) -> None:
+        if not self.state.rebase_entries:
+            win.addstr(1, 2, "No commits queued for rebase.")
+            return
+        win.addstr(1, 2, "Interactive Rebase Plan (Enter to launch, Esc to cancel)", curses.A_BOLD)
+        for idx, entry in enumerate(self.state.rebase_entries):
+            prefix = "➤" if idx == self.state.rebase_cursor else " "
+            line = f"{prefix} {entry.action:<7} {entry.commit.short_hash} {entry.commit.subject}"
+            attr = curses.color_pair(self.colors["default"])
+            if idx == self.state.rebase_cursor:
+                attr |= curses.A_REVERSE
+            win.addstr(idx + 2, 2, line[:width], attr)
+        win.addstr(len(self.state.rebase_entries) + 3, 2, "Keys: p pick | s squash | f fixup | e edit | r reword | x drop")
+
+    def _render_plugin_panel(self, win: curses.window, width: int) -> None:
+        if not self.plugins:
+            win.addstr(1, 2, "No plug-ins discovered. Drop modules into plugins/ to extend.")
+            return
+        win.addstr(1, 2, "Plug-ins (Enter to run) - output on the right", curses.A_BOLD)
+        for idx, plugin in enumerate(self.plugins):
+            prefix = "➤" if idx == self.state.plugin_index else " "
+            line = f"{prefix} {plugin.name}: {plugin.description}"
+            attr = curses.color_pair(self.colors["default"])
+            if idx == self.state.plugin_index:
+                attr |= curses.A_REVERSE
+            win.addstr(idx + 2, 2, line[:width], attr)
+        if self.state.plugin_output:
+            lines = self.state.plugin_output.splitlines()
+            height, _ = win.getmaxyx()
+            split = min(len(lines), height - 2)
+            for idx in range(split):
+                win.addstr(idx + 1, width // 2, lines[idx][: width // 2 - 2])
+
+    def _render_danger_panel(self, win: curses.window, width: int) -> None:
+        skull = [
+            "      .-.",
+            "     (o o)",
+            "  .oooO--(_)--Oooo."
+        ]
+        for idx, line in enumerate(skull):
+            win.addstr(idx + 1, 2, line, curses.color_pair(self.colors["danger"]))
+        instructions = [
+            "Danger Zone", "", "R: rollback to selected commit (hard reset)",
+            "P: force push current branch", "S: stash working tree", "Esc: close",
+        ]
+        for idx, line in enumerate(instructions):
+            win.addstr(idx + 1, 20, line[: width - 22])
+
+    def _render_help_overlay(self) -> None:
+        max_y, max_x = self.stdscr.getmaxyx()
+        height = len(HELP_TEXT) + 4
+        width = max(len(line) for line in HELP_TEXT) + 6
+        win = curses.newwin(height, width, max_y // 2 - height // 2, max_x // 2 - width // 2)
+        win.bkgd(" ", curses.color_pair(self.colors["panel"]))
+        win.box()
+        win.addstr(1, 2, "Hotkeys", curses.A_BOLD)
+        for idx, line in enumerate(HELP_TEXT, start=2):
+            win.addstr(idx, 2, line)
+        win.noutrefresh()
+
+    def _render_danger_overlay(self) -> None:
+        max_y, max_x = self.stdscr.getmaxyx()
+        height = 10
+        width = 60
+        win = curses.newwin(height, width, max_y // 2 - height // 2, max_x // 2 - width // 2)
+        win.bkgd(" ", curses.color_pair(self.colors["danger"]))
+        win.box()
+        win.addstr(1, 2, "!!! DANGER ZONE !!!", curses.A_BOLD)
+        win.addstr(3, 2, "Press R to rollback, P to force push, S to stash. Esc closes.")
+        win.addstr(5, 2, "Animated skull incoming... ☠")
+        win.noutrefresh()
+
+    # -------------------------------------------------------------- data helpers
+    def _get_diff(self, commit: Commit) -> str:
+        if commit.hash not in self.diff_cache:
+            try:
+                diff = self.git.get_diff(commit.hash)
+            except GitCommandError as exc:
+                diff = f"Failed to load diff: {exc}"
+            self.diff_cache[commit.hash] = diff
+        return self.diff_cache[commit.hash]
+
+    def _ensure_github_data(self, tab: str):
+        if tab in self.github_cache:
+            return self.github_cache[tab]
+        if not self.github:
+            return []
+        try:
+            if tab == "issues":
+                data = self.github.list_issues()
+            elif tab == "pulls":
+                data = self.github.list_pull_requests()
+            else:
+                data = self.github.list_workflows()
+            self.github_cache[tab] = data
+            return data
+        except GitHubUnavailable as exc:
+            self.state.github_error = str(exc)
+            return []
+
+    # --------------------------------------------------------------- interactions
+    def run(self) -> None:
+        while True:
+            self.render()
+            key = self.stdscr.getch()
+            if key == -1:
+                continue
+            if not self.handle_key(key):
+                break
+
+    def handle_key(self, key: int) -> bool:
+        if key in (ord("q"), ord("Q")):
+            return False
+        if key == ord("?"):
+            self.state.help_visible = not self.state.help_visible
+            return True
+        if key in (ord("d"), ord("D")):
+            if self.state.danger_mode:
+                self.state.danger_mode = False
+                self.state.view = "diff"
+            else:
+                self.state.view = "danger"
+                self.state.danger_mode = True
+            return True
+        if self.state.danger_mode:
+            return self._handle_danger_key(key)
+        if self.state.view == "rebase":
+            return self._handle_rebase_key(key)
+        if self.state.view == "plugins":
+            return self._handle_plugin_key(key)
+        if key in (curses.KEY_UP, ord("k")):
+            self._move_selection(-1)
+            return True
+        if key in (curses.KEY_DOWN, ord("j")):
+            self._move_selection(1)
+            return True
+        if key == curses.KEY_PPAGE:
+            self._move_selection(-5)
+            return True
+        if key == curses.KEY_NPAGE:
+            self._move_selection(5)
+            return True
+        if key == ord("g"):
+            self.state.view = "github"
+            self._ensure_github_data(self.state.github_tab)
+            return True
+        if key == ord("b") or key == ord("B"):
+            self.state.view = "branches"
+            return True
+        if key == ord("r") or key == ord("R"):
+            self._open_rebase_planner()
+            return True
+        if key == ord("p"):
+            self._stash_worktree()
+            return True
+        if key == ord("P"):
+            self.state.view = "plugins"
+            return True
+        if key == ord("u"):
+            self._undo()
+            return True
+        if key == ord("U"):
+            self._redo()
+            return True
+        if key == ord("/"):
+            self._search()
+            return True
+        if key in (curses.KEY_LEFT, curses.KEY_RIGHT):
+            if self.state.view == "github":
+                self._cycle_github_tab(-1 if key == curses.KEY_LEFT else 1)
+            return True
+        if key == ord(" "):
+            self._checkout_temp_branch()
+            return True
+        if key == ord("\t"):
+            self._create_branch_from_commit()
+            return True
+        if key == ord("f") or key == ord("F"):
+            self._fast_forward()
+            return True
+        if key == ord("m") or key == ord("M"):
+            self._merge()
+            return True
+        if key == ord("\n"):
+            self.state.view = "diff"
+            return True
+        return True
+
+    def _move_selection(self, delta: int) -> None:
+        new_index = min(max(self.state.selected + delta, 0), len(self.state.commits) - 1)
+        if new_index != self.state.selected:
+            self.state.selected = new_index
+            self.state.status = f"Selected commit {self.state.commits[new_index].short_hash}"
+
+    # ----------------------------------------------------------- git operations
+    def _checkout_temp_branch(self) -> None:
+        commit = self.state.commits[self.state.selected]
+        if not self._confirm(f"Checkout {commit.short_hash} in temp branch?"):
+            return
+        snapshot = self.git.snapshot_head()
+        try:
+            branch = self.git.checkout_temporary_branch(commit)
+        except GitCommandError as exc:
+            self.state.status = str(exc)
+            return
+        self.state.undo_stack.append(snapshot)
+        self.state.redo_stack.clear()
+        self.state.status = f"Checked out {commit.short_hash} into {branch}"
+
+    def _create_branch_from_commit(self) -> None:
+        commit = self.state.commits[self.state.selected]
+        default = f"feature/{commit.subject[:20].replace(' ', '-').lower()}"
+        name = self._prompt("New branch name:", default=default)
+        if not name:
+            return
+        try:
+            self.git.create_branch(name, commit.hash)
+            self.state.status = f"Branch {name} created at {commit.short_hash}"
+        except GitCommandError as exc:
+            self.state.status = str(exc)
+
+    def _fast_forward(self) -> None:
+        snapshot = self.git.snapshot_head()
+        try:
+            branch = self.git.fast_forward()
+            self.state.status = f"Fast-forwarded to origin/{branch}"
+            self.state.undo_stack.append(snapshot)
+            self.state.redo_stack.clear()
+            self._refresh_commits()
+        except GitCommandError as exc:
+            self.state.status = str(exc)
+
+    def _merge(self) -> None:
+        ref = self._prompt("Merge which branch/ref into current?", default="origin/main")
+        if not ref:
+            return
+        preview = self.git.merge_preview(ref)
+        if not self._confirm(f"Apply merge for {ref}?\n\nPreview:\n{preview[:200]}..."):
+            return
+        snapshot = self.git.snapshot_head()
+        try:
+            output = self.git.merge(ref)
+            self.state.status = output.splitlines()[0] if output else f"Merged {ref}"
+            self.state.undo_stack.append(snapshot)
+            self.state.redo_stack.clear()
+            self._refresh_commits()
+        except GitCommandError as exc:
+            self.state.status = str(exc)
+
+    def _stash_worktree(self) -> None:
+        if not self._confirm("Stash current working tree?"):
+            return
+        try:
+            message = self.git.stash()
+            self.state.status = message.strip() or "Working tree stashed."
+        except GitCommandError as exc:
+            self.state.status = str(exc)
+
+    def _undo(self) -> None:
+        if not self.state.undo_stack:
+            self.state.status = "Undo stack empty."
+            return
+        snapshot = self.state.undo_stack.pop()
+        redo = self.git.snapshot_head()
+        try:
+            self.git.restore_snapshot(snapshot)
+            self.state.redo_stack.append(redo)
+            self.state.status = "Undo complete."
+            self._refresh_commits()
+        except GitCommandError as exc:
+            self.state.status = str(exc)
+
+    def _redo(self) -> None:
+        if not self.state.redo_stack:
+            self.state.status = "Redo stack empty."
+            return
+        snapshot = self.state.redo_stack.pop()
+        undo = self.git.snapshot_head()
+        try:
+            self.git.restore_snapshot(snapshot)
+            self.state.undo_stack.append(undo)
+            self.state.status = "Redo complete."
+            self._refresh_commits()
+        except GitCommandError as exc:
+            self.state.status = str(exc)
+
+    # --------------------------------------------------------------- rebase mode
+    def _open_rebase_planner(self) -> None:
+        entries = self.git.build_rebase_todo(5)
+        if len(entries) <= 1:
+            self.state.status = "Not enough commits for rebase."
+            return
+        entries.reverse()  # show oldest first
+        self.state.rebase_entries = [RebaseEntry(commit=commit) for commit in entries]
+        self.state.rebase_cursor = 0
+        self.state.view = "rebase"
+        self.state.status = "Interactive rebase planner ready."
+
+    def _handle_rebase_key(self, key: int) -> bool:
+        if key == 27:  # ESC
+            self.state.view = "diff"
+            self.state.rebase_entries.clear()
+            return True
+        if key in (curses.KEY_UP, ord("k")):
+            self.state.rebase_cursor = max(0, self.state.rebase_cursor - 1)
+            return True
+        if key in (curses.KEY_DOWN, ord("j")):
+            self.state.rebase_cursor = min(len(self.state.rebase_entries) - 1, self.state.rebase_cursor + 1)
+            return True
+        if key in (ord("p"), ord("s"), ord("f"), ord("e"), ord("r"), ord("x")):
+            mapping = {
+                ord("p"): "pick",
+                ord("s"): "squash",
+                ord("f"): "fixup",
+                ord("e"): "edit",
+                ord("r"): "reword",
+                ord("x"): "drop",
+            }
+            self.state.rebase_entries[self.state.rebase_cursor].action = mapping[key]
+            return True
+        if key in (10, 13):
+            self._launch_rebase()
+            return True
+        return True
+
+    def _launch_rebase(self) -> None:
+        actions = [(entry.action, entry.commit) for entry in self.state.rebase_entries]
+        if not self._confirm("Execute interactive rebase with current plan?"):
+            return
+        snapshot = self.git.snapshot_head()
+        try:
+            self.git.run_interactive_rebase(actions)
+            self.state.undo_stack.append(snapshot)
+            self.state.redo_stack.clear()
+            self.state.status = "Rebase completed."
+            self.state.view = "diff"
+            self._refresh_commits()
+        except GitCommandError as exc:
+            self.state.status = str(exc)
+
+    # ------------------------------------------------------------- plugin panel
+    def _handle_plugin_key(self, key: int) -> bool:
+        if key in (curses.KEY_UP, ord("k")):
+            self.state.plugin_index = max(0, self.state.plugin_index - 1)
+            return True
+        if key in (curses.KEY_DOWN, ord("j")):
+            self.state.plugin_index = min(len(self.plugins) - 1, self.state.plugin_index + 1)
+            return True
+        if key in (10, 13):
+            plugin = self.plugins[self.state.plugin_index]
+            try:
+                output = plugin.run(self.git, self)
+            except Exception as exc:  # pragma: no cover - defensive
+                output = f"Plugin {plugin.name} failed: {exc}"
+            self.state.plugin_output = output
+            self.state.status = f"Plugin {plugin.name} executed."
+            return True
+        if key == 27:  # ESC
+            self.state.view = "diff"
+            return True
+        return True
+
+    # -------------------------------------------------------------- danger keys
+    def _handle_danger_key(self, key: int) -> bool:
+        if key == 27:
+            self.state.danger_mode = False
+            self.state.view = "diff"
+            return True
+        if key in (ord("r"), ord("R")):
+            commit = self.state.commits[self.state.selected]
+            if not self._confirm(f"Hard reset to {commit.short_hash}? This cannot be undone!"):
+                return True
+            snapshot = self.git.snapshot_head()
+            try:
+                self.git.rollback_hard(commit.hash)
+                self.state.status = f"Rolled back to {commit.short_hash}."
+                self.state.undo_stack.append(snapshot)
+                self.state.redo_stack.clear()
+                self._refresh_commits()
+            except GitCommandError as exc:
+                self.state.status = str(exc)
+            return True
+        if key in (ord("p"), ord("P")):
+            branch = self.git.current_branch()
+            if not branch:
+                self.state.status = "Cannot force push detached HEAD."
+                return True
+            if not self._confirm(f"Force push {branch}? Animated skull approves?"):
+                return True
+            snapshot = self.git.snapshot_head()
+            try:
+                message = self.git.force_push(branch)
+                self.state.status = message.splitlines()[0] if message else f"Force pushed {branch}."
+                self.state.undo_stack.append(snapshot)
+                self.state.redo_stack.clear()
+            except GitCommandError as exc:
+                self.state.status = str(exc)
+            return True
+        if key in (ord("s"), ord("S")):
+            self._stash_worktree()
+            return True
+        return True
+
+    # ---------------------------------------------------------- helper methods
+    def _refresh_commits(self) -> None:
+        self.state.commits = self.git.list_commits()
+        self.state.selected = min(self.state.selected, len(self.state.commits) - 1)
+        self.diff_cache.clear()
+
+    def _cycle_github_tab(self, delta: int) -> None:
+        idx = GITHUB_TABS.index(self.state.github_tab)
+        idx = (idx + delta) % len(GITHUB_TABS)
+        self.state.github_tab = GITHUB_TABS[idx]
+        self._ensure_github_data(self.state.github_tab)
+        self.state.status = f"Viewing GitHub {self.state.github_tab}."
+
+    def _search(self) -> None:
+        query = self._prompt("Search commits or #number:")
+        if not query:
+            return
+        if query.startswith("#") and query[1:].isdigit() and self.github:
+            number = int(query[1:])
+            try:
+                item = self.github.lookup_issue_or_pr(number)
+                lines = [
+                    f"#{item.number} [{item.type}] {item.title}",
+                    f"State: {item.state}",
+                    f"Author: {item.author}",
+                    item.url,
+                ]
+                self.state.plugin_output = "\n".join(lines)
+                self.state.view = "github"
+                self.state.status = f"Loaded GitHub item #{number}."
+                return
+            except GitHubUnavailable as exc:
+                self.state.status = str(exc)
+                return
+        # Fallback to commit search
+        for idx, commit in enumerate(self.state.commits):
+            if query.lower() in commit.subject.lower() or query.lower() in commit.short_hash.lower():
+                self.state.selected = idx
+                self.state.view = "diff"
+                self.state.status = f"Jumped to {commit.short_hash}"
+                return
+        self.state.status = "No matches found."
+
+    def _prompt(self, prompt: str, default: str = "") -> str:
+        max_y, max_x = self.stdscr.getmaxyx()
+        width = max(len(prompt) + 20, 40)
+        win = curses.newwin(5, width, max_y // 2 - 2, max_x // 2 - width // 2)
+        win.bkgd(" ", curses.color_pair(self.colors["panel"]))
+        win.box()
+        win.addstr(1, 2, prompt)
+        win.addstr(2, 2, default)
+        curses.echo()
+        win.refresh()
+        try:
+            value = win.getstr(2, 2 + len(default), width - 4 - len(default)).decode()
+        finally:
+            curses.noecho()
+        return value or default
+
+    def _confirm(self, prompt: str) -> bool:
+        max_y, max_x = self.stdscr.getmaxyx()
+        width = min(max(len(prompt) + 6, 40), max_x - 4)
+        win = curses.newwin(5, width, max_y // 2 - 2, max_x // 2 - width // 2)
+        win.bkgd(" ", curses.color_pair(self.colors["panel"]))
+        win.box()
+        wrapped = self._wrap_text(prompt, width - 4)
+        for idx, line in enumerate(wrapped[:2]):
+            win.addstr(1 + idx, 2, line)
+        win.addstr(3, 2, "[y]es / [n]o?")
+        win.refresh()
+        while True:
+            ch = win.getch()
+            if ch in (ord("y"), ord("Y")):
+                return True
+            if ch in (ord("n"), ord("N"), 27):
+                return False
+
+    def _wrap_text(self, text: str, width: int) -> List[str]:
+        words = text.split()
+        lines: List[str] = []
+        current: List[str] = []
+        length = 0
+        for word in words:
+            if length + len(word) + 1 > width and current:
+                lines.append(" ".join(current))
+                current = [word]
+                length = len(word) + 1
+            else:
+                current.append(word)
+                length += len(word) + 1
+        if current:
+            lines.append(" ".join(current))
+        return lines
+
+
+def run() -> None:
+    curses.wrapper(lambda stdscr: NeonGitApp(stdscr).run())

--- a/neogit_tui/config.py
+++ b/neogit_tui/config.py
@@ -1,0 +1,133 @@
+"""Configuration and theme helpers for the neon Git cockpit."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+import curses
+
+CONFIG_DIR = Path.home() / ".config" / "neon_git"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+# Mapping of theme names to basic colour roles. We keep the palette small so it
+# works well in curses where only 8 base colours are guaranteed.
+THEME_DEFINITIONS = {
+    "github_dark": {
+        "background": "black",
+        "foreground": "white",
+        "accent": "cyan",
+        "panel": "blue",
+        "muted": "magenta",
+        "warning": "yellow",
+        "success": "green",
+        "danger": "red",
+    },
+    "matrix_green": {
+        "background": "black",
+        "foreground": "green",
+        "accent": "green",
+        "panel": "black",
+        "muted": "cyan",
+        "warning": "yellow",
+        "success": "green",
+        "danger": "red",
+    },
+    "neon_cyberpunk": {
+        "background": "black",
+        "foreground": "white",
+        "accent": "magenta",
+        "panel": "cyan",
+        "muted": "blue",
+        "warning": "yellow",
+        "success": "green",
+        "danger": "magenta",
+    },
+}
+
+COLOR_NAME_TO_CURSES = {
+    "black": curses.COLOR_BLACK,
+    "blue": curses.COLOR_BLUE,
+    "cyan": curses.COLOR_CYAN,
+    "green": curses.COLOR_GREEN,
+    "magenta": curses.COLOR_MAGENTA,
+    "red": curses.COLOR_RED,
+    "white": curses.COLOR_WHITE,
+    "yellow": curses.COLOR_YELLOW,
+}
+
+
+@dataclass
+class Theme:
+    """Resolved theme definition."""
+
+    name: str
+    palette: Dict[str, int]
+
+
+def _ensure_config_dir() -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _default_config() -> Dict[str, str]:
+    return {"theme": "github_dark"}
+
+
+def load_user_config() -> Dict[str, str]:
+    """Load (and create) the user configuration file."""
+
+    if not CONFIG_FILE.exists():
+        _ensure_config_dir()
+        CONFIG_FILE.write_text(json.dumps(_default_config(), indent=2))
+    try:
+        data = json.loads(CONFIG_FILE.read_text())
+    except json.JSONDecodeError:
+        data = _default_config()
+    return data
+
+
+def resolve_theme(preferred: str | None = None) -> Theme:
+    """Return the active theme as a :class:`Theme`."""
+
+    config = load_user_config()
+    theme_name = preferred or config.get("theme", "github_dark")
+    if theme_name not in THEME_DEFINITIONS:
+        theme_name = "github_dark"
+    palette = {
+        role: COLOR_NAME_TO_CURSES.get(colour, curses.COLOR_WHITE)
+        for role, colour in THEME_DEFINITIONS[theme_name].items()
+    }
+    return Theme(name=theme_name, palette=palette)
+
+
+def apply_theme(theme: Theme) -> Dict[str, int]:
+    """Initialise curses colour pairs for the theme."""
+
+    curses.start_color()
+    try:
+        curses.use_default_colors()
+    except curses.error:
+        # Not all terminals support default colours; ignore.
+        pass
+
+    pairs = {
+        "default": 1,
+        "accent": 2,
+        "panel": 3,
+        "muted": 4,
+        "warning": 5,
+        "success": 6,
+        "danger": 7,
+    }
+
+    curses.init_pair(pairs["default"], theme.palette["foreground"], theme.palette["background"])
+    curses.init_pair(pairs["accent"], theme.palette["accent"], theme.palette["background"])
+    curses.init_pair(pairs["panel"], theme.palette["foreground"], theme.palette["panel"])
+    curses.init_pair(pairs["muted"], theme.palette["muted"], theme.palette["background"])
+    curses.init_pair(pairs["warning"], theme.palette["warning"], theme.palette["background"])
+    curses.init_pair(pairs["success"], theme.palette["success"], theme.palette["background"])
+    curses.init_pair(pairs["danger"], theme.palette["danger"], theme.palette["background"])
+
+    return pairs

--- a/neogit_tui/git.py
+++ b/neogit_tui/git.py
@@ -1,0 +1,256 @@
+"""Git plumbing helpers for the neon Git cockpit."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+
+class GitCommandError(RuntimeError):
+    """Raised when a git command exits unsuccessfully."""
+
+    def __init__(self, command: Sequence[str], returncode: int, stdout: str, stderr: str):
+        self.command = list(command)
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        message = stderr.strip() or stdout.strip() or "Unknown git error"
+        super().__init__(f"git {' '.join(command)} failed ({returncode}): {message}")
+
+
+@dataclass
+class Commit:
+    hash: str
+    short_hash: str
+    author: str
+    date: str
+    subject: str
+
+
+@dataclass
+class HeadSnapshot:
+    branch: Optional[str]
+    commit: str
+
+
+class GitInterface:
+    """A thin convenience wrapper around git commands."""
+
+    def __init__(self, repo_path: Path | str | None = None):
+        self.repo_path = Path(repo_path or Path.cwd())
+        if not (self.repo_path / ".git").exists():
+            raise GitCommandError(["rev-parse"], 128, "", f"Not a git repository: {self.repo_path}")
+
+    # ------------------------------------------------------------------ basics
+    def _run(
+        self,
+        *args: str,
+        check: bool = True,
+        capture_output: bool = True,
+        env: Optional[dict] = None,
+    ) -> subprocess.CompletedProcess:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=self.repo_path,
+            text=True,
+            capture_output=capture_output,
+            env={**os.environ, **(env or {})},
+        )
+        if check and result.returncode != 0:
+            raise GitCommandError(args, result.returncode, result.stdout, result.stderr)
+        return result
+
+    # ---------------------------------------------------------------- commits
+    def list_commits(self, limit: int = 200) -> List[Commit]:
+        result = self._run(
+            "log",
+            f"--max-count={limit}",
+            "--date=short",
+            "--pretty=format:%H%x09%h%x09%an%x09%ad%x09%s",
+        )
+        commits: List[Commit] = []
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split("\t", 4)
+            if len(parts) < 5:
+                continue
+            full, short, author, date, subject = parts
+            commits.append(Commit(full, short, author, date, subject))
+        return commits
+
+    def get_diff(self, commit_hash: str, context: int = 3) -> str:
+        result = self._run("show", commit_hash, f"-U{context}", "--color=never")
+        return result.stdout
+
+    # --------------------------------------------------------------- references
+    def current_branch(self) -> Optional[str]:
+        result = self._run("rev-parse", "--abbrev-ref", "HEAD")
+        branch = result.stdout.strip()
+        return None if branch == "HEAD" else branch
+
+    def default_branch(self) -> str:
+        try:
+            result = self._run("symbolic-ref", "refs/remotes/origin/HEAD")
+            ref = result.stdout.strip()
+            if ref.startswith("refs/remotes/origin/"):
+                return ref.split("/")[-1]
+        except GitCommandError:
+            pass
+        for candidate in ("main", "master", "develop"):
+            try:
+                self._run("rev-parse", f"origin/{candidate}")
+                return candidate
+            except GitCommandError:
+                continue
+        return "main"
+
+    def branch_exists(self, branch: str) -> bool:
+        try:
+            self._run("rev-parse", "--verify", branch)
+            return True
+        except GitCommandError:
+            return False
+
+    def list_branches(self) -> str:
+        result = self._run("branch", "--all", "--verbose", "--color=never")
+        return result.stdout
+
+    def branch_graph(self) -> str:
+        result = self._run("log", "--graph", "--decorate", "--oneline", "--all")
+        return result.stdout
+
+    # ----------------------------------------------------------------- actions
+    def checkout(self, ref: str) -> None:
+        self._run("checkout", ref)
+
+    def create_branch(self, branch: str, commit: str) -> None:
+        self._run("branch", branch, commit)
+
+    def switch(self, branch: str) -> None:
+        self._run("switch", branch)
+
+    def checkout_temporary_branch(self, commit: Commit) -> str:
+        base = f"play/{commit.short_hash}"
+        name = base
+        counter = 1
+        while self.branch_exists(name):
+            counter += 1
+            name = f"{base}-{counter}"
+        self._run("switch", "-c", name, commit.hash)
+        return name
+
+    def fast_forward(self, target: Optional[str] = None) -> str:
+        branch = target or self.default_branch()
+        self._run("fetch", "origin", branch)
+        self._run("merge", "--ff-only", f"origin/{branch}")
+        return branch
+
+    def merge_preview(self, ref: str) -> str:
+        result = self._run("diff", "--stat", f"HEAD...{ref}")
+        return result.stdout
+
+    def merge(self, ref: str) -> str:
+        result = self._run("merge", ref)
+        return result.stdout
+
+    def force_push(self, branch: Optional[str] = None) -> str:
+        target = branch or self.current_branch()
+        if not target:
+            raise GitCommandError(["push"], 1, "", "Cannot force push in detached HEAD state")
+        result = self._run("push", "--force-with-lease", "origin", target)
+        return result.stdout
+
+    def rollback_hard(self, commit: str) -> None:
+        self._run("reset", "--hard", commit)
+
+    def working_tree_is_clean(self) -> bool:
+        result = self._run("status", "--porcelain")
+        return result.stdout.strip() == ""
+
+    def stash(self) -> str:
+        result = self._run("stash")
+        return result.stdout
+
+    def status_short(self) -> List[str]:
+        result = self._run("status", "--short")
+        return [line.rstrip() for line in result.stdout.splitlines()]
+
+    def diff_stat(self, ref: Optional[str] = None) -> str:
+        args = ["diff", "--stat"]
+        if ref:
+            args.append(ref)
+        result = self._run(*args)
+        return result.stdout
+
+    # ----------------------------------------------------------- undo / redo
+    def snapshot_head(self) -> HeadSnapshot:
+        branch = self.current_branch()
+        commit = self._run("rev-parse", "HEAD").stdout.strip()
+        return HeadSnapshot(branch=branch, commit=commit)
+
+    def restore_snapshot(self, snapshot: HeadSnapshot) -> None:
+        if snapshot.branch:
+            self._run("switch", snapshot.branch)
+        else:
+            self._run("checkout", snapshot.commit)
+
+    # ------------------------------------------------------------- rebase todo
+    def build_rebase_todo(self, count: int) -> List[Commit]:
+        result = self._run(
+            "log",
+            f"--max-count={count}",
+            "--pretty=format:%H%x09%h%x09%an%x09%ad%x09%s",
+        )
+        commits: List[Commit] = []
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            full, short, author, date, subject = line.split("\t", 4)
+            commits.append(Commit(full, short, author, date, subject))
+        return commits
+
+    def run_interactive_rebase(self, actions: List[tuple[str, Commit]]) -> None:
+        if not actions:
+            return
+        todo_lines = [f"{action} {commit.hash} {commit.subject}".strip() for action, commit in actions]
+        depth = len(actions)
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            tmp.write("\n".join(todo_lines))
+            tmp.flush()
+            env = {
+                "GIT_SEQUENCE_EDITOR": f"cat {tmp.name}",
+            }
+            self._run("rebase", "-i", f"HEAD~{depth}", env=env)
+        os.unlink(tmp.name)
+
+    # ------------------------------------------------------------- repo info
+    def remote_url(self) -> Optional[str]:
+        try:
+            result = self._run("config", "--get", "remote.origin.url")
+            return result.stdout.strip() or None
+        except GitCommandError:
+            return None
+
+    def repo_slug(self) -> Optional[str]:
+        url = self.remote_url()
+        if not url:
+            return None
+        cleaned = url
+        if cleaned.endswith(".git"):
+            cleaned = cleaned[:-4]
+        if cleaned.startswith("git@"):
+            cleaned = cleaned.replace(":", "/", 1)
+            cleaned = cleaned.split("@", 1)[-1]
+        if cleaned.startswith("https://") or cleaned.startswith("http://"):
+            cleaned = cleaned.split("//", 1)[-1]
+        parts = cleaned.split("/")
+        if len(parts) >= 2:
+            owner = parts[-2]
+            name = parts[-1]
+            return f"{owner}/{name}"
+        return None

--- a/neogit_tui/github.py
+++ b/neogit_tui/github.py
@@ -1,0 +1,173 @@
+"""GitHub integrations for the neon Git cockpit."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from .git import GitInterface
+
+
+class GitHubUnavailable(RuntimeError):
+    """Raised when GitHub features cannot be used."""
+
+
+@dataclass
+class GitHubItem:
+    number: int
+    title: str
+    state: str
+    url: str
+    author: str
+    updated_at: str
+    type: str
+
+
+@dataclass
+class WorkflowRun:
+    name: str
+    status: str
+    conclusion: Optional[str]
+    url: str
+    created_at: str
+
+
+class GitHubClient:
+    """Thin wrapper around the GitHub CLI (gh)."""
+
+    def __init__(self, git: GitInterface):
+        if shutil.which("gh") is None:
+            raise GitHubUnavailable("GitHub CLI (gh) is not installed.")
+        self.git = git
+        slug = git.repo_slug()
+        if not slug:
+            raise GitHubUnavailable("Cannot resolve repository slug from git remotes.")
+        self.slug = slug
+
+    # ---------------------------------------------------------------- utilities
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        result = subprocess.run(
+            ["gh", *args],
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            raise GitHubUnavailable(result.stderr.strip() or result.stdout.strip())
+        return result
+
+    def _api_json(self, endpoint: str, params: Optional[Dict[str, str]] = None) -> object:
+        command = ["api", endpoint]
+        params = params or {}
+        for key, value in params.items():
+            command.extend(["-f", f"{key}={value}"])
+        result = self._run(*command)
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise GitHubUnavailable(f"Failed to parse GitHub response: {exc}") from exc
+
+    # -------------------------------------------------------------------- issues
+    def list_issues(self, state: str = "open", limit: int = 20) -> List[GitHubItem]:
+        data = self._api_json(
+            f"repos/{self.slug}/issues",
+            {"state": state, "per_page": str(limit)},
+        )
+        items: List[GitHubItem] = []
+        for entry in data:
+            if "pull_request" in entry:
+                # The issues endpoint returns PRs as well; skip them here.
+                continue
+            items.append(
+                GitHubItem(
+                    number=entry["number"],
+                    title=entry["title"],
+                    state=entry["state"],
+                    url=entry.get("html_url", ""),
+                    author=entry.get("user", {}).get("login", "unknown"),
+                    updated_at=entry.get("updated_at", ""),
+                    type="issue",
+                )
+            )
+        return items
+
+    # ------------------------------------------------------------------------ PRs
+    def list_pull_requests(self, state: str = "open", limit: int = 20) -> List[GitHubItem]:
+        data = self._api_json(
+            f"repos/{self.slug}/pulls",
+            {"state": state, "per_page": str(limit)},
+        )
+        items: List[GitHubItem] = []
+        for entry in data:
+            items.append(
+                GitHubItem(
+                    number=entry["number"],
+                    title=entry["title"],
+                    state=entry["state"],
+                    url=entry.get("html_url", ""),
+                    author=entry.get("user", {}).get("login", "unknown"),
+                    updated_at=entry.get("updated_at", ""),
+                    type="pull",
+                )
+            )
+        return items
+
+    # --------------------------------------------------------------- workflow runs
+    def list_workflows(self, limit: int = 10) -> List[WorkflowRun]:
+        data = self._api_json(
+            f"repos/{self.slug}/actions/runs",
+            {"per_page": str(limit)},
+        )
+        runs: List[WorkflowRun] = []
+        for entry in data.get("workflow_runs", []):
+            runs.append(
+                WorkflowRun(
+                    name=entry.get("name", entry.get("display_title", "workflow")),
+                    status=entry.get("status", "unknown"),
+                    conclusion=entry.get("conclusion"),
+                    url=entry.get("html_url", ""),
+                    created_at=entry.get("created_at", ""),
+                )
+            )
+        return runs
+
+    # ------------------------------------------------------------------- searching
+    def lookup_issue_or_pr(self, number: int) -> GitHubItem:
+        data = self._api_json(f"repos/{self.slug}/issues/{number}")
+        item_type = "pull" if "pull_request" in data else "issue"
+        return GitHubItem(
+            number=data["number"],
+            title=data["title"],
+            state=data["state"],
+            url=data.get("html_url", ""),
+            author=data.get("user", {}).get("login", "unknown"),
+            updated_at=data.get("updated_at", ""),
+            type=item_type,
+        )
+
+    def merge_pull_request(self, number: int, method: str = "merge") -> str:
+        if method not in {"merge", "squash", "rebase"}:
+            method = "merge"
+        flag = f"--{method}"
+        result = self._run("pr", "merge", str(number), flag, "--repo", self.slug, "--auto")
+        return result.stdout.strip()
+
+    def comment(self, number: int, body: str) -> str:
+        result = self._run(
+            "api",
+            f"repos/{self.slug}/issues/{number}/comments",
+            "-X",
+            "POST",
+            "-f",
+            f"body={body}",
+        )
+        return result.stdout.strip()
+
+
+def try_create_client(git: GitInterface) -> GitHubClient | None:
+    try:
+        return GitHubClient(git)
+    except GitHubUnavailable:
+        return None

--- a/neogit_tui/plugins/__init__.py
+++ b/neogit_tui/plugins/__init__.py
@@ -1,0 +1,41 @@
+"""Plugin loading for the neon Git cockpit."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Callable, List
+
+from ..git import GitInterface
+
+
+@dataclass
+class Plugin:
+    name: str
+    description: str
+    run: Callable[[GitInterface, Any], str]
+
+
+def load_plugins() -> List[Plugin]:
+    plugins: List[Plugin] = []
+    base = Path(__file__).parent
+    for module_path in base.glob("*.py"):
+        if module_path.name == "__init__.py":
+            continue
+        module_name = f"{__name__}.{module_path.stem}"
+        try:
+            module = import_module(module_name)
+        except Exception:
+            continue
+        register = getattr(module, "register", None)
+        if register is None:
+            continue
+        try:
+            plugin = register()
+        except Exception:
+            continue
+        if plugin:
+            plugins.append(plugin)
+    plugins.sort(key=lambda plug: plug.name.lower())
+    return plugins

--- a/neogit_tui/plugins/ml_suggester.py
+++ b/neogit_tui/plugins/ml_suggester.py
@@ -1,0 +1,57 @@
+"""Playful commit message suggester plugin."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from ..git import GitInterface
+from . import Plugin
+
+
+FILE_HINTS = {
+    ".py": "python", ".sh": "shell", ".md": "docs", ".yml": "config",
+    ".yaml": "config", ".json": "config", ".js": "javascript", ".ts": "typescript",
+}
+
+
+def _categorise(paths: list[str]) -> Counter[str]:
+    buckets: Counter[str] = Counter()
+    for path in paths:
+        suffix = Path(path).suffix.lower()
+        bucket = FILE_HINTS.get(suffix, "general change")
+        buckets[bucket] += 1
+    return buckets
+
+
+def suggest_commit_message(git: GitInterface, _: Any) -> str:
+    status_lines = git.status_short()
+    if not status_lines:
+        return "Working tree is clean – nothing to commit!"
+    paths = [line[3:] for line in status_lines if len(line) > 3]
+    buckets = _categorise(paths)
+    primary = buckets.most_common(2)
+    stat = git.diff_stat()
+    summary_parts = [f"{count} {name}" for name, count in primary]
+    summary = ", ".join(summary_parts) if summary_parts else "assorted updates"
+    suggestions = [
+        f"chore: polish {summary}",
+        f"feat: evolve {primary[0][0]} flow" if primary else "feat: add improvements",
+        "refactor: streamline repo per diff stats",
+    ]
+    report = ["🤖 Commit Message Oracle", "", "Top suggestions:"]
+    for idx, idea in enumerate(suggestions, start=1):
+        report.append(f"  {idx}. {idea}")
+    report.append("")
+    report.append("Diff footprint:")
+    report.extend([f"  {line}" for line in stat.splitlines()[:10]])
+    return "\n".join(report)
+
+
+def register() -> Plugin:
+    return Plugin(
+        name="ML-ish Commit Oracle",
+        description="Generate cheeky commit message suggestions based on current diffs.",
+        run=suggest_commit_message,
+    )


### PR DESCRIPTION
## Summary
- add a curses-driven neon git cockpit with commit timeline, diff viewer, branch/danger/rebase modes, undo/redo, and plugin launcher
- wrap git/GitHub interactions and theming in reusable helpers backing the cockpit
- document the neon cockpit UX, keybindings, and plugin architecture in the README

## Testing
- python -m compileall neogit.py neogit_tui

------
https://chatgpt.com/codex/tasks/task_e_68ceb572a62c832cbbceaac45dbbd5ca