### PR TITLE
Fix curses rendering blank screen

### DIFF
--- a/neogit_tui/app.py
+++ b/neogit_tui/app.py
@@ -101,7 +101,11 @@ class NeonGitApp:
         if self.state.danger_mode:
             self._render_danger_overlay()
 
-        self.stdscr.refresh()
+        # All child windows call ``noutrefresh`` so we need to follow up with a
+        # ``doupdate`` to paint them to the terminal. ``refresh`` only updates
+        # the stdscr buffer which left the UI blank.
+        self.stdscr.noutrefresh()
+        curses.doupdate()
 
     def _render_header(self, win: curses.window) -> None:
         win.bkgd(" ", curses.color_pair(self.colors["panel"]))


### PR DESCRIPTION
## Summary
- ensure the curses cockpit flushes window updates via doupdate so the UI renders
- document why refresh was insufficient when every panel uses noutrefresh

## Testing
- python -m compileall neogit_tui

------
https://chatgpt.com/codex/tasks/task_e_68cebebc2c24832c8d9903d3458c9a72