### PR TITLE
Fix blank neogit screen rendering

### DIFF
--- a/neogit_tui/app.py
+++ b/neogit_tui/app.py
@@ -102,9 +102,10 @@ class NeonGitApp:
             self._render_danger_overlay()
 
         # All child windows call ``noutrefresh`` so we need to follow up with a
-        # ``doupdate`` to paint them to the terminal. ``refresh`` only updates
-        # the stdscr buffer which left the UI blank.
-        self.stdscr.noutrefresh()
+        # ``doupdate`` to paint them to the terminal. Importantly we *do not*
+        # ``noutrefresh`` the ``stdscr`` here. Doing so after erasing it would
+        # mark the whole screen as blank and clobber the child window updates,
+        # resulting in the empty screen reported by users.
         curses.doupdate()
 
     def _render_header(self, win: curses.window) -> None:


### PR DESCRIPTION
## Summary
- stop calling `noutrefresh` on the root screen so child windows remain visible
- document why the UI previously appeared blank after launching the cockpit

## Testing
- python -m compileall neogit_tui

------
https://chatgpt.com/codex/tasks/task_e_68cec0238f74832ca53e800489483817