### PR TITLE
Add Dockerfile and requirements placeholder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    TERM=xterm-256color
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "-m", "git_helper"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# gitHelper does not require any external Python packages at runtime.
+# This placeholder keeps tools that expect a requirements file happy.


### PR DESCRIPTION
## Summary
- add a placeholder requirements.txt so pip-based tooling has a manifest even though the app only uses the stdlib
- add a Python 3.11 Dockerfile that installs git and openssh-client, installs requirements, and defaults to running the git_helper CLI

## Testing
- python -m compileall git_helper neogit_tui

------
https://chatgpt.com/codex/tasks/task_e_68cf3af82938832c8eb86380c3045a25