### PR TITLE
Add git workflow commands and contextual help to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ The CLI surfaces the most common actions behind friendly menus and emoji-powered
 
 * **Repository directory management** – review the active workspace, switch to a different folder, or create it on the fly with automatic validation and recovery when paths are invalid.
 * **Repository overview** – quickly list all Git repositories that live under the configured workspace.
+* **Git repository workflow** – select or initialise projects, stage files, craft commits, and push/pull with upstream tracking prompts.
 * **SSH key concierge** – generate fresh Ed25519 keys, import existing keys into `~/.ssh`, and optionally register them with the local `ssh-agent`, all with detailed success and error messaging.
 
 The interface is implemented as a first-class Python package (`git_helper`) making it easy to install with `pip`, script against, or extend. Rich inline documentation and modular components keep future maintenance approachable.
+
+> Pro tip: type `?` or `help` on any screen to open a contextual help panel summarising available shortcuts and actions.
 
 ## Neon Git Cockpit (Terminal UI)
 

--- a/git_helper/__init__.py
+++ b/git_helper/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/git_helper/cli.py
+++ b/git_helper/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 from . import __version__
 from .console import (
@@ -19,6 +20,7 @@ from .console import (
 )
 from .directory import RepositoryDirectoryManager
 from .errors import DirectoryError, SSHKeyError
+from .git import GitRepository, GitRepositoryError
 from .ssh import SSHKeyManager
 
 __all__ = ["GitHelperApp", "main"]
@@ -30,6 +32,7 @@ class GitHelperApp:
     def __init__(self) -> None:
         self.repo_manager = RepositoryDirectoryManager()
         self.ssh_manager = SSHKeyManager()
+        self.active_repository: Optional[Path] = None
 
     # ----------------------------------------------------------------- utilities
     def _show_header(self, title: str) -> None:
@@ -45,6 +48,47 @@ class GitHelperApp:
         else:
             info(f"Active repository directory: {current}")
 
+    def _show_current_repository(self) -> None:
+        if not self.active_repository:
+            info("Active repository: none selected. Use the git workflow menu to choose one.")
+            return
+        repo = GitRepository(self.active_repository)
+        state = "initialised" if repo.is_repository else "not initialised"
+        info(f"Active repository: {self.active_repository} ({state})")
+
+    def _show_help(self, topic: str = "main") -> None:
+        topics = {
+            "main": [
+                "Use the numbered options or their shortcuts (e.g. 'ssh') to navigate.",
+                "Configure the workspace directory before working with repositories.",
+                "Visit the Git repository workflow to initialise repos and run commits.",
+                "An active repository is remembered between actions; select it once and reuse it.",
+                "Type '?' or 'help' on any screen to see context-aware tips.",
+            ],
+            "directory": [
+                "Change repository directory updates the stored workspace path.",
+                "Refresh reloads configuration from disk in case it was edited manually.",
+                "Use full paths or paths relative to your home directory when prompted.",
+            ],
+            "ssh": [
+                "Generate creates a new Ed25519 key pair inside ~/.ssh by default.",
+                "Import copies an existing private key into ~/.ssh and can add it to ssh-agent.",
+                "Add to agent allows any key to be loaded into the current ssh-agent session.",
+            ],
+            "repository": [
+                "Select repository chooses which project subsequent Git actions will use.",
+                "Initialise can create a brand new repository anywhere on disk and optionally add a remote.",
+                "Stage all runs 'git add --all' for the active repository.",
+                "Commit prompts for a message and performs 'git commit'.",
+                "Push and Pull wrap the respective Git commands and offer sensible defaults.",
+                "Configure remote adds or updates the URL for remotes such as 'origin'.",
+            ],
+        }
+        self._show_header("Help")
+        bullet_list(topics.get(topic, topics["main"]))
+        info("Press Enter to return to the previous menu.")
+        input()
+
     # -------------------------------------------------------------- main menus
     def run(self) -> None:
         """Launch the application loop."""
@@ -52,12 +96,14 @@ class GitHelperApp:
         while True:
             self._show_header("Control Centre")
             self._show_current_directory()
+            self._show_current_repository()
             info("Choose an operation:")
             bullet_list(
                 [
                     "[1] Manage repository directory",
                     "[2] View repositories in current directory",
                     "[3] SSH key management",
+                    "[4] Git repository workflow",
                     "[Q] Quit",
                 ]
             )
@@ -68,6 +114,10 @@ class GitHelperApp:
                 self._list_repositories()
             elif choice in {"3", "ssh"}:
                 self._ssh_menu()
+            elif choice in {"4", "git", "g"}:
+                self._repository_menu()
+            elif choice in {"?", "h", "help"}:
+                self._show_help("main")
             elif choice in {"q", "quit"}:
                 success("Thanks for using gitHelper. Goodbye!")
                 return
@@ -92,6 +142,8 @@ class GitHelperApp:
             elif choice in {"2", "refresh"}:
                 self.repo_manager.refresh()
                 success("Configuration reloaded.")
+            elif choice in {"?", "h", "help"}:
+                self._show_help("directory")
             elif choice in {"b", "back"}:
                 return
             else:
@@ -147,6 +199,8 @@ class GitHelperApp:
                 self._import_key()
             elif choice in {"3", "agent", "a"}:
                 self._add_key_to_agent()
+            elif choice in {"?", "h", "help"}:
+                self._show_help("ssh")
             elif choice in {"b", "back"}:
                 return
             else:
@@ -206,6 +260,273 @@ class GitHelperApp:
             error(str(exc))
         else:
             success("Key added to ssh-agent.")
+            if output:
+                info(output)
+
+    # ------------------------------------------------------------- git actions
+    def _require_repository(self, *, allow_uninitialised: bool = False) -> GitRepository | None:
+        if not self.active_repository:
+            warning("No active repository selected. Choose 'Select repository' first.")
+            return None
+        repo = GitRepository(self.active_repository)
+        if not repo.exists:
+            warning(f"{self.active_repository} does not exist. Initialise it first.")
+            return None
+        if not allow_uninitialised and not repo.is_repository:
+            warning(
+                f"{self.active_repository} is not a Git repository. Choose 'Initialise new repository' to set it up."
+            )
+            return None
+        return repo
+
+    def _repository_menu(self) -> None:
+        while True:
+            self._show_header("Git repository workflow")
+            self._show_current_repository()
+            bullet_list(
+                [
+                    "[1] Select repository",
+                    "[2] Initialise new repository",
+                    "[3] Show status",
+                    "[4] Stage all changes",
+                    "[5] Commit staged changes",
+                    "[6] Push to remote",
+                    "[7] Pull from remote",
+                    "[8] Configure remote",
+                    "[B] Back to main menu",
+                ]
+            )
+            choice = prompt("Select an option").strip().lower()
+            if choice in {"1", "select", "s"}:
+                self._select_repository()
+            elif choice in {"2", "init", "i"}:
+                self._initialise_repository()
+            elif choice in {"3", "status"}:
+                self._show_status()
+            elif choice in {"4", "stage", "a"}:
+                self._stage_all()
+            elif choice in {"5", "commit", "c"}:
+                self._commit_changes()
+            elif choice in {"6", "push", "p"}:
+                self._push_changes()
+            elif choice in {"7", "pull", "l"}:
+                self._pull_changes()
+            elif choice in {"8", "remote", "r"}:
+                self._configure_remote()
+            elif choice in {"?", "h", "help"}:
+                self._show_help("repository")
+            elif choice in {"b", "back"}:
+                return
+            else:
+                warning("Unknown option. Please select one of the listed commands.")
+
+    def _select_repository(self) -> None:
+        try:
+            repositories = self.repo_manager.list_repositories()
+        except DirectoryError as exc:
+            error(str(exc))
+            repositories = []
+
+        if repositories:
+            info("Repositories discovered in the configured directory:")
+            items = [f"[{idx + 1}] {repo}" for idx, repo in enumerate(repositories)]
+            bullet_list(items)
+            default = "1" if len(repositories) == 1 else ""
+            response = prompt(
+                "Enter the number of the repository to use or provide a custom path",
+                default=default,
+            )
+        else:
+            warning("No repositories detected. Enter a path manually.")
+            response = prompt("Repository path")
+
+        if not response.strip():
+            warning("No repository selected.")
+            return
+
+        selected_path: Path
+        if response.isdigit() and repositories:
+            index = int(response) - 1
+            if not 0 <= index < len(repositories):
+                warning("Selection out of range.")
+                return
+            selected_path = repositories[index]
+        else:
+            selected_path = Path(response).expanduser()
+
+        self.active_repository = selected_path
+        repo = GitRepository(selected_path)
+        if repo.is_repository:
+            success(f"Active repository set to {selected_path}")
+        else:
+            warning(
+                f"{selected_path} is not initialised yet. Choose 'Initialise new repository' before running Git commands."
+            )
+
+    def _initialise_repository(self) -> None:
+        default_path: str | None = None
+        if self.active_repository:
+            default_path = str(self.active_repository)
+        else:
+            try:
+                default_path = str(self.repo_manager.current_directory())
+            except DirectoryError:
+                default_path = None
+
+        target_input = prompt("Directory to initialise", default=default_path).strip()
+        if not target_input:
+            warning("No directory supplied; cancelled initialisation.")
+            return
+
+        target = Path(target_input).expanduser()
+        repo = GitRepository(target)
+        if target.exists() and not target.is_dir():
+            error(f"{target} exists but is not a directory.")
+            return
+        if not target.exists():
+            create = confirm(f"{target} does not exist. Create it?", default=True)
+            if not create:
+                warning("Initialisation aborted.")
+                return
+
+        default_branch = prompt("Initial branch name", default="main").strip()
+        try:
+            output = repo.init(default_branch=default_branch or None)
+        except GitRepositoryError as exc:
+            error(str(exc))
+            return
+
+        self.active_repository = target
+        success(f"Initialised Git repository in {target}")
+        if output:
+            info(output)
+
+        remote_url = prompt("Remote URL to add (leave empty to skip)").strip()
+        if remote_url:
+            try:
+                remote_output = repo.set_remote("origin", remote_url, replace=True)
+            except GitRepositoryError as exc:
+                error(str(exc))
+            else:
+                info(remote_output or "Remote 'origin' updated.")
+
+    def _show_status(self) -> None:
+        repo = self._require_repository()
+        if not repo:
+            return
+        try:
+            output = repo.status()
+        except GitRepositoryError as exc:
+            error(str(exc))
+            return
+        info("Repository status:")
+        if output:
+            for line in output.splitlines():
+                print(line)
+
+    def _stage_all(self) -> None:
+        repo = self._require_repository()
+        if not repo:
+            return
+        try:
+            repo.stage_all()
+        except GitRepositoryError as exc:
+            error(str(exc))
+        else:
+            success("All changes staged.")
+
+    def _commit_changes(self) -> None:
+        repo = self._require_repository()
+        if not repo:
+            return
+        message = prompt("Commit message").strip()
+        if not message:
+            warning("Commit message is required.")
+            return
+        try:
+            output = repo.commit(message)
+        except GitRepositoryError as exc:
+            error(str(exc))
+        else:
+            success("Commit created successfully.")
+            if output:
+                info(output)
+
+    def _push_changes(self) -> None:
+        repo = self._require_repository()
+        if not repo:
+            return
+        default_remote = "origin"
+        current_branch = repo.current_branch()
+        remote = prompt("Remote to push to", default=default_remote).strip() or default_remote
+        branch = prompt("Branch to push", default=current_branch or "").strip()
+        if not branch:
+            warning("Branch name is required to push.")
+            return
+        tracking = repo.tracking_branch()
+        set_upstream_default = tracking is None
+        if set_upstream_default:
+            info("No upstream configured for this branch. An upstream will be set during push.")
+        set_upstream = confirm(
+            "Set upstream while pushing?",
+            default=set_upstream_default,
+        )
+        try:
+            output = repo.push(remote, branch, set_upstream=set_upstream)
+        except GitRepositoryError as exc:
+            error(str(exc))
+        else:
+            success("Push completed successfully.")
+            if output:
+                info(output)
+
+    def _pull_changes(self) -> None:
+        repo = self._require_repository()
+        if not repo:
+            return
+        default_remote = "origin"
+        current_branch = repo.current_branch()
+        if not current_branch:
+            warning("Cannot pull while in a detached HEAD state.")
+            return
+        remote = prompt("Remote to pull from", default=default_remote).strip() or default_remote
+        branch = prompt("Branch to pull", default=current_branch).strip()
+        if not branch:
+            warning("Branch name is required to pull.")
+            return
+        try:
+            output = repo.pull(remote, branch)
+        except GitRepositoryError as exc:
+            error(str(exc))
+        else:
+            success("Pull completed successfully.")
+            if output:
+                info(output)
+
+    def _configure_remote(self) -> None:
+        repo = self._require_repository()
+        if not repo:
+            return
+        remote_name = prompt("Remote name", default="origin").strip() or "origin"
+        remote_url = prompt("Remote URL").strip()
+        if not remote_url:
+            warning("Remote URL is required.")
+            return
+        replace = repo.remote_exists(remote_name)
+        if replace:
+            replace = confirm(
+                f"Remote '{remote_name}' already exists. Update its URL?",
+                default=True,
+            )
+            if not replace:
+                warning("Remote update cancelled.")
+                return
+        try:
+            output = repo.set_remote(remote_name, remote_url, replace=True)
+        except GitRepositoryError as exc:
+            error(str(exc))
+        else:
+            success(f"Remote '{remote_name}' configured.")
             if output:
                 info(output)
 

--- a/git_helper/git.py
+++ b/git_helper/git.py
@@ -1,0 +1,171 @@
+"""High level helpers for interacting with Git repositories."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import List, Sequence
+
+__all__ = [
+    "GitRepository",
+    "GitRepositoryError",
+]
+
+
+class GitRepositoryError(RuntimeError):
+    """Raised when an underlying Git command fails."""
+
+
+class GitRepository:
+    """Small convenience wrapper around ``git`` commands.
+
+    The helper focuses on the handful of operations needed by the interactive
+    CLI.  It keeps the implementation lightweight while still surfacing useful
+    error information when Git is misconfigured or unavailable.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path).expanduser()
+
+    # ----------------------------------------------------------------- helpers
+    def _ensure_directory(self) -> None:
+        try:
+            self.path.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:  # pragma: no cover - platform specific
+            raise GitRepositoryError(f"Unable to create directory {self.path}: {exc}")
+
+    def _ensure_repository(self) -> None:
+        if not self.is_repository:
+            raise GitRepositoryError(
+                f"{self.path} is not an initialised Git repository. Run git init first."
+            )
+
+    def _run(self, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+        command: Sequence[str] = ("git", *args)
+        try:
+            result = subprocess.run(
+                command,
+                cwd=self.path,
+                text=True,
+                capture_output=True,
+            )
+        except FileNotFoundError as exc:
+            raise GitRepositoryError("The 'git' executable is not available on PATH.") from exc
+
+        if check and result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip()
+            if not message:
+                message = f"git {' '.join(args)} failed with exit code {result.returncode}"
+            raise GitRepositoryError(message)
+        return result
+
+    # ------------------------------------------------------------------- status
+    @property
+    def exists(self) -> bool:
+        return self.path.exists()
+
+    @property
+    def is_repository(self) -> bool:
+        return (self.path / ".git").is_dir()
+
+    def status(self) -> str:
+        """Return ``git status`` output for the repository."""
+
+        self._ensure_repository()
+        result = self._run("status", "--short", "--branch")
+        output = result.stdout.strip()
+        return output or "Nothing to commit, working tree clean."
+
+    # ------------------------------------------------------------------ actions
+    def init(self, *, default_branch: str | None = None) -> str:
+        """Initialise a repository at the configured path."""
+
+        self._ensure_directory()
+        args = ["init"]
+        if default_branch:
+            args.extend(["--initial-branch", default_branch])
+        result = self._run(*args)
+        return result.stdout.strip() or result.stderr.strip()
+
+    def stage_all(self) -> None:
+        """Stage all tracked and untracked changes."""
+
+        self._ensure_repository()
+        self._run("add", "--all")
+
+    def commit(self, message: str) -> str:
+        """Create a commit with *message* and return Git's response."""
+
+        self._ensure_repository()
+        if not message.strip():
+            raise GitRepositoryError("A commit message is required.")
+        result = self._run("commit", "-m", message)
+        return result.stdout.strip() or result.stderr.strip()
+
+    def current_branch(self) -> str | None:
+        """Return the current branch name or ``None`` when detached."""
+
+        self._ensure_repository()
+        result = self._run("rev-parse", "--abbrev-ref", "HEAD")
+        branch = result.stdout.strip()
+        return None if branch == "HEAD" else branch
+
+    def tracking_branch(self) -> str | None:
+        """Return the upstream tracking branch if configured."""
+
+        self._ensure_repository()
+        result = self._run(
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{u}",
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        value = result.stdout.strip()
+        return value or None
+
+    def push(self, remote: str, branch: str, *, set_upstream: bool = False) -> str:
+        """Push the current branch to *remote* and return Git's output."""
+
+        self._ensure_repository()
+        args = ["push"]
+        if set_upstream:
+            args.append("--set-upstream")
+        args.extend([remote, branch])
+        result = self._run(*args)
+        return result.stdout.strip() or result.stderr.strip()
+
+    def pull(self, remote: str, branch: str) -> str:
+        """Pull the given *branch* from *remote* and return Git's output."""
+
+        self._ensure_repository()
+        result = self._run("pull", remote, branch)
+        return result.stdout.strip() or result.stderr.strip()
+
+    def remotes(self) -> List[str]:
+        """Return a list of configured remote names."""
+
+        self._ensure_repository()
+        result = self._run("remote")
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def remote_exists(self, name: str) -> bool:
+        return name in self.remotes()
+
+    def set_remote(self, name: str, url: str, *, replace: bool = False) -> str:
+        """Add or update a remote."""
+
+        self._ensure_repository()
+        if not url.strip():
+            raise GitRepositoryError("A remote URL is required.")
+        if self.remote_exists(name):
+            if not replace:
+                raise GitRepositoryError(
+                    f"Remote '{name}' already exists. Enable replace=True to update it."
+                )
+            result = self._run("remote", "set-url", name, url)
+        else:
+            result = self._run("remote", "add", name, url)
+        return result.stdout.strip() or result.stderr.strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "git-helper"
-version = "0.1.0"
+version = "0.2.0"
 description = "Interactive command line helper for Git workflows"
 requires-python = ">=3.11"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- add a lightweight GitRepository helper to wrap key git commands
- extend the interactive CLI with contextual help and a git workflow menu
- document the new workflow features in the README and bump the package version

## Testing
- `python -m compileall git_helper`


------
https://chatgpt.com/codex/tasks/task_e_68cf3d992e9c832cac374d00b12b5595