### PR TITLE
Prompt for repository path during onboarding

### DIFF
--- a/git_helper/utils/config.py
+++ b/git_helper/utils/config.py
@@ -35,6 +35,9 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "default_org": "",
         "preferred_repos": [],
     },
+    "workspace": {
+        "repo_path": "",
+    },
     "ui": {
         "theme": "system",
         "use_gui": False,
@@ -93,6 +96,7 @@ class ConfigManager:
 
     def profile_summary(self) -> str:
         github = self.data.get("github", {})
+        workspace = self.data.get("workspace", {})
         ui = self.data.get("ui", {})
         editor = self.data.get("editor", {})
         lines = ["gitHelper profile summary:"]
@@ -102,6 +106,11 @@ class ConfigManager:
             lines.append("- Preferred repositories: " + ", ".join(preferred))
         else:
             lines.append("- Preferred repositories: none configured")
+        repo_path = workspace.get("repo_path")
+        if repo_path:
+            lines.append(f"- Default repository: {repo_path}")
+        else:
+            lines.append("- Default repository: not set")
         lines.append(f"- Preferred editor: {editor.get('command')}")
         lines.append(f"- UI theme: {ui.get('theme', 'system')}")
         lines.append(f"- GUI fallback enabled: {'yes' if ui.get('use_gui') else 'no'}")


### PR DESCRIPTION
## Summary
- load the configured repository path during CLI bootstrap and fall back when missing
- prompt for a repository path at the start of onboarding and persist it in the workspace config
- surface the saved repository path in the profile summary for visibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9a75a5c14832c8b0826c931f81faf